### PR TITLE
refactor: use app_name for service account and kubernetes secret creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ module "cortex_app" {
   ingress_dns                     = "example.com"
   load_balancer_ingress_name      = "ingress"
   load_balancer_ingress_namespace = "infra"
-  consul_helm_values_override     = file("${path.module}/example_consul.yaml")
-  cortex_helm_values_override     = file("${path.module}/example_cortex.yaml")
 }
 ```
 
@@ -42,28 +40,31 @@ module "cortex_app" {
 
 ## Inputs
 
-| Name                            | Description                                                                                                           | Type     | Default    | Required |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------------------- | -------- | ---------- | :------: |
-| app_name                        | n/a                                                                                                                   | `string` | `"cortex"` |    no    |
-| aws_zone_id                     | AWS DNS zone Id for ingress creation                                                                                  | `string` | n/a        |   yes    |
-| consul_helm_values_override     | String in yaml format to override helm values for consul. Ref: https://github.com/odpf/charts/tree/main/stable/consul | `string` | `""`       |    no    |
-| cortex_helm_values_override     | String in yaml format to override helm values for cortex. Ref: https://github.com/cortexproject/cortex-helm-chart     | `string` | `""`       |    no    |
-| ingress_dns                     | Domain name for ingress                                                                                               | `string` | n/a        |   yes    |
-| ingress_enabled                 | n/a                                                                                                                   | `bool`   | `true`     |    no    |
-| labels                          | n/a                                                                                                                   | `map`    | `{}`       |    no    |
-| load_balancer_ingress_name      | Loadbalancer ingress service name for kubernetes_service data resource                                                | `string` | n/a        |   yes    |
-| load_balancer_ingress_namespace | Loadbalancer ingress service namespace for kubernetes_service data resource                                           | `any`    | n/a        |   yes    |
-| namespace                       | n/a                                                                                                                   | `string` | `"cortex"` |    no    |
-| network_name                    | GCP Network name                                                                                                      | `string` | n/a        |   yes    |
-| project_name                    | GCP Project name                                                                                                      | `string` | n/a        |   yes    |
-| region                          | GCP Network region/location. eg: asia-southeast1                                                                      | `string` | n/a        |   yes    |
+## Inputs
+
+| Name                            | Description                                                                                                                                 | Type     | Default                                                                                                                                                                                                 | Required |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------: |
+| app_name                        | n/a                                                                                                                                         | `string` | `"cortex"`                                                                                                                                                                                              |    no    |
+| aws_zone_id                     | AWS DNS zone Id for ingress creation                                                                                                        | `string` | n/a                                                                                                                                                                                                     |   yes    |
+| consul_helm_release_config      | Configs mapped to terraform helm_release provider. Ref:https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release | `map`    | <pre>{<br> "chart": "consul",<br> "repository": "https://odpf.github.io/charts",<br> "timeout": 150,<br> "values_override": "",<br> "version": "0.1.0",<br> "wait": true<br>}</pre>                     |    no    |
+| cortex_helm_release_config      | Configs mapped to terraform helm_release provider. Ref:https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release | `map`    | <pre>{<br> "chart": "cortex",<br> "repository": "https://cortexproject.github.io/cortex-helm-chart",<br> "timeout": 600,<br> "values_override": "",<br> "version": "0.4.0",<br> "wait": true<br>}</pre> |    no    |
+| ingress_dns                     | Domain name for ingress                                                                                                                     | `string` | n/a                                                                                                                                                                                                     |   yes    |
+| ingress_enabled                 | n/a                                                                                                                                         | `bool`   | `true`                                                                                                                                                                                                  |    no    |
+| labels                          | n/a                                                                                                                                         | `map`    | `{}`                                                                                                                                                                                                    |    no    |
+| load_balancer_ingress_name      | Loadbalancer ingress service name for kubernetes_service data resource                                                                      | `string` | n/a                                                                                                                                                                                                     |   yes    |
+| load_balancer_ingress_namespace | Loadbalancer ingress service namespace for kubernetes_service data resource                                                                 | `any`    | n/a                                                                                                                                                                                                     |   yes    |
+| namespace                       | n/a                                                                                                                                         | `string` | `"cortex"`                                                                                                                                                                                              |    no    |
+| network_name                    | GCP Network name                                                                                                                            | `string` | n/a                                                                                                                                                                                                     |   yes    |
+| project_name                    | GCP Project name                                                                                                                            | `string` | n/a                                                                                                                                                                                                     |   yes    |
+| region                          | GCP Network region/location. eg: asia-southeast1                                                                                            | `string` | n/a                                                                                                                                                                                                     |   yes    |
 
 ## Outputs
 
-| Name     | Description                          |
-| -------- | ------------------------------------ |
-| bucket   | GCS Bucket details for block storage |
-| memcache | GCP memory store details             |
+| Name        | Description                          |
+| ----------- | ------------------------------------ |
+| bucket      | GCS Bucket details for block storage |
+| ingress_dns | DNS zone record details for ingress  |
+| memcache    | GCP memory store details             |
 
 ## Requirements
 

--- a/data.tf
+++ b/data.tf
@@ -1,4 +1,8 @@
 data "kubernetes_service" "cortex" {
+
+  depends_on = [
+    helm_release.cortex
+  ]
   metadata {
     name      = var.load_balancer_ingress_name
     namespace = var.load_balancer_ingress_namespace

--- a/main.tf
+++ b/main.tf
@@ -60,27 +60,29 @@ resource "helm_release" "consul" {
   name             = "${var.app_name}-consul"
   namespace        = var.namespace
   create_namespace = true
-  repository       = "https://odpf.github.io/charts"
-  chart            = "consul"
-  version          = "0.1.0"
+  repository       = var.consul_helm_release_config.repository
+  chart            = var.consul_helm_release_config.chart
+  version          = var.consul_helm_release_config.version
+  wait             = var.consul_helm_release_config.wait
+  timeout          = var.consul_helm_release_config.timeout
   values = [
     templatefile("${path.module}/templates/consul.yaml", {
       "labels" = jsonencode(local.labels)
     }),
-    var.consul_helm_values_override
+    var.consul_helm_release_config.values_override
   ]
 }
 
 resource "helm_release" "cortex" {
   name              = var.app_name
   namespace         = var.namespace
+  repository        = var.cortex_helm_release_config.repository
+  chart             = var.cortex_helm_release_config.chart
+  version           = var.cortex_helm_release_config.version
+  wait              = var.cortex_helm_release_config.wait
+  timeout           = var.cortex_helm_release_config.timeout
   create_namespace  = true
   dependency_update = true
-  repository        = "https://cortexproject.github.io/cortex-helm-chart"
-  chart             = "cortex"
-  version           = "0.4.0"
-  wait              = true
-  timeout           = 1200
   values = [
     templatefile("${path.module}/templates/cortex.yaml", {
       memcached = {
@@ -93,9 +95,9 @@ resource "helm_release" "cortex" {
         host = "${var.app_name}-consul.${var.namespace}.svc.cluster.local:8500"
       },
       "host_ingress" = var.ingress_dns
-      "app_name" = var.app_name
+      "app_name"     = var.app_name
     }),
-    var.cortex_helm_values_override
+    var.cortex_helm_release_config.values_override
   ]
 
   depends_on = [

--- a/main.tf
+++ b/main.tf
@@ -31,11 +31,11 @@ resource "google_service_account_key" "service_account_key" {
 
 resource "kubernetes_secret" "cortex-google-credentials" {
   metadata {
-    name      = "cortex-google-credentials"
+    name      = "${var.app_name}-google-credentials"
     namespace = var.namespace
-    labels    = { app = "cortex" }
+    labels    = merge(var.labels, { app = var.app_name })
     annotations = {
-      "kubernetes.io/service-account.name" = "cortex-google-credentials"
+      "kubernetes.io/service-account.name" = "${var.app_name}-google-credentials"
     }
   }
 
@@ -79,8 +79,8 @@ resource "helm_release" "cortex" {
   repository        = "https://cortexproject.github.io/cortex-helm-chart"
   chart             = "cortex"
   version           = "0.4.0"
-  wait              = false
-  timeout           = 600
+  wait              = true
+  timeout           = 1200
   values = [
     templatefile("${path.module}/templates/cortex.yaml", {
       memcached = {
@@ -93,6 +93,7 @@ resource "helm_release" "cortex" {
         host = "${var.app_name}-consul.${var.namespace}.svc.cluster.local:8500"
       },
       "host_ingress" = var.ingress_dns
+      "app_name" = var.app_name
     }),
     var.cortex_helm_values_override
   ]

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,7 @@ output "memcache" {
   value       = google_memcache_instance.cortex
   description = "GCP memory store details"
 }
+
+output "ingress_dns" {
+  value = (var.ingress_enabled)? aws_route53_record.dns_ingress[0] : null
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,5 +9,6 @@ output "memcache" {
 }
 
 output "ingress_dns" {
+  description = "DNS zone record details for ingress"
   value = (var.ingress_enabled)? aws_route53_record.dns_ingress[0] : null
 }

--- a/templates/cortex.yaml
+++ b/templates/cortex.yaml
@@ -107,11 +107,11 @@ ruler:
   podAnnotations:
     prometheus.io/newrelic-scrape: 'true'
   extraVolumes:
-    - name: cortex-google-credentials
+    - name: ${app_name}-google-credentials
       secret:
-        secretName: cortex-google-credentials
+        secretName: ${app_name}-google-credentials
   extraVolumeMounts:
-    - name: cortex-google-credentials
+    - name: ${app_name}-google-credentials
       mountPath: /etc/cortex/google/
   env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -122,11 +122,11 @@ querier:
   podAnnotations:
     prometheus.io/newrelic-scrape: 'true'
   extraVolumes:
-    - name: cortex-google-credentials
+    - name: ${app_name}-google-credentials
       secret:
-        secretName: cortex-google-credentials
+        secretName: ${app_name}-google-credentials
   extraVolumeMounts:
-    - name: cortex-google-credentials
+    - name: ${app_name}-google-credentials
       mountPath: /etc/cortex/google/
   env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -146,12 +146,12 @@ distributor:
 
 nginx:
   enabled: true
-  replicas: 4
   annotations:
     cloud.google.com/load-balancer-type: Internal
   serviceType: LoadBalancer
   config:
     client_max_body_size: 5M
+  replicas: 2
   podAnnotations:
     prometheus.io/newrelic-scrape: 'false'
   resources:
@@ -179,11 +179,11 @@ ingester:
     size: 30Gi
 
   extraVolumes:
-    - name: cortex-google-credentials
+    - name: ${app_name}-google-credentials
       secret:
-        secretName: cortex-google-credentials
+        secretName: ${app_name}-google-credentials
   extraVolumeMounts:
-    - name: cortex-google-credentials
+    - name: ${app_name}-google-credentials
       mountPath: /etc/cortex/google/
   env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -212,11 +212,11 @@ store_gateway:
     prometheus.io/newrelic-scrape: 'true'
 
   extraVolumes:
-    - name: cortex-google-credentials
+    - name: ${app_name}-google-credentials
       secret:
-        secretName: cortex-google-credentials
+        secretName: ${app_name}-google-credentials
   extraVolumeMounts:
-    - name: cortex-google-credentials
+    - name: ${app_name}-google-credentials
       mountPath: /etc/cortex/google/
   env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -230,12 +230,12 @@ compactor:
   persistentVolume:
     size: 150Gi
   extraVolumes:
-    - name: cortex-google-credentials
+    - name: ${app_name}-google-credentials
       secret:
-        secretName: cortex-google-credentials
+        secretName: ${app_name}-google-credentials
         defaultMode: 0640
   extraVolumeMounts:
-    - name: cortex-google-credentials
+    - name: ${app_name}-google-credentials
       mountPath: /etc/cortex/google/
   env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -253,14 +253,14 @@ alertmanager:
       cpu: 1000m
       memory: 500Mi
   extraVolumes:
-    - name: cortex-google-credentials
+    - name: ${app_name}-google-credentials
       secret:
-        secretName: cortex-google-credentials
+        secretName: ${app_name}-google-credentials
         defaultMode: 0640
     - name: tmp-volume
       emptyDir: { }
   extraVolumeMounts:
-    - name: cortex-google-credentials
+    - name: ${app_name}-google-credentials
       mountPath: /etc/cortex/google/
     - name: tmp-volume
       mountPath: /tmp

--- a/variables.tf
+++ b/variables.tf
@@ -51,12 +51,26 @@ variable "load_balancer_ingress_namespace" {
   description = "Loadbalancer ingress service namespace for kubernetes_service data resource"
 }
 
-variable "consul_helm_values_override" {
-  default     = ""
-  description = "String in yaml format to override helm values for consul. Ref: https://github.com/odpf/charts/tree/main/stable/consul"
+variable "consul_helm_release_config" {
+  default = {
+    wait            = true,
+    timeout         = 150,
+    repository      = "https://odpf.github.io/charts"
+    chart           = "consul"
+    version         = "0.1.0"
+    values_override = "" ## String in yaml format to override helm values for consul. Ref: https://github.com/odpf/charts/tree/main/stable/consul
+  }
+  description = "Configs mapped to terraform helm_release provider. Ref:https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release"
 }
 
-variable "cortex_helm_values_override" {
-  default     = ""
-  description = "String in yaml format to override helm values for cortex. Ref: https://github.com/cortexproject/cortex-helm-chart"
+variable "cortex_helm_release_config" {
+  default = {
+    wait            = true,
+    timeout         = 600,
+    repository      = "https://cortexproject.github.io/cortex-helm-chart",
+    chart           = "cortex",
+    version         = "0.4.0",
+    values_override = "" ## String in yaml format to override helm values for consul. Ref: https://github.com/odpf/charts/tree/main/stable/consul
+  }
+  description = "Configs mapped to terraform helm_release provider. Ref:https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release"
 }


### PR DESCRIPTION
- Created service account name prepended with `app_name`
- Used same name in config for cortex