### PR TITLE
feat: add seperate bucket for storing ruler and alertmanager configs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,11 @@
-output "bucket" {
-  value       = google_storage_bucket.cortex
+output "data_bucket" {
+  value       = google_storage_bucket.cortex_data
   description = "GCS Bucket details for block storage"
+}
+
+output "config_bucket" {
+  value       = google_storage_bucket.cortex_configs
+  description = "GCS Bucket details for configs"
 }
 
 output "memcache" {

--- a/templates/cortex.yaml
+++ b/templates/cortex.yaml
@@ -24,7 +24,7 @@ config:
   storage:
     engine: blocks
     gcs:
-      bucket_name: "${gcs.bucket_name}"
+      bucket_name: "${gcs.data_bucket_name}"
     index_queries_cache_config:
       memcached_client:
         addresses: ${memcached.addresses}
@@ -32,7 +32,7 @@ config:
   blocks_storage:
     backend: gcs
     gcs:
-      bucket_name: "${gcs.bucket_name}"
+      bucket_name: "${gcs.data_bucket_name}"
     bucket_store:
       sync_dir: "/data/tsdb-sync"
       index_cache:
@@ -70,7 +70,7 @@ config:
     storage:
       type: gcs
       gcs:
-        bucket_name: "${gcs.bucket_name}"
+        bucket_name: "${gcs.configs_bucket_name}"
     enable_sharding: true
     ring:
       kvstore:
@@ -98,7 +98,7 @@ config:
     storage:
       type: gcs
       gcs:
-        bucket_name: "${gcs.bucket_name}"
+        bucket_name: "${gcs.configs_bucket_name}"
         request_timeout: 50s
 
 ## Root configs


### PR DESCRIPTION
**BREAKING**
Alertmanager and Ruler configs should be stored in separate bucket than tsdb data.
Reference issue - https://github.com/cortexproject/cortex/issues/4093


Co-authored-by: Abhishek <abhi.sah.97@gmail.com>